### PR TITLE
fix(typings): add namespace to fix library import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare module "reading-time" {
     minutes: number;
   };
   
-  namespace readingTime {};
+  namespace readingTime {}
 
   export = readingTime;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,8 @@ declare module "reading-time" {
     words: number;
     minutes: number;
   };
+  
+  namespace readingTime {};
 
   export = readingTime;
 }


### PR DESCRIPTION
This PR allows the library to be imported using `import * as readingTime from 'reading-time`.
See https://github.com/Microsoft/TypeScript/issues/5073 for more information.