### PR TITLE
Updated the typings file so we can pass options in when using TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It works perfectly with plain text, but also with `markdown` or `html`.
 Note that it's focused on performance and simplicity, so the number of words it will extract from other formats than
 plain text can vary a little. But this is an estimation right?
 
-[Medium]: https://medium.com
+[medium]: https://medium.com
 
 ## Installation
 
@@ -42,21 +42,24 @@ var stats = readingTime(text);
 ```javascript
 var readingTime = require('reading-time/stream');
 
-fs.createReadStream('foo').pipe(readingTime).on('data', function(stats) {
-	// ...
-});
+fs.createReadStream('foo')
+  .pipe(readingTime)
+  .on('data', function(stats) {
+    // ...
+  });
 ```
 
 ## API
 
-`readingTime(text, options)`
+`readingTime(text, options?)`
 
- - `text`: the text to analyze
- - `options.wordsPerMinute`: the words per minute an average reader can read (default: 200)
- - `options.wordBound`: a function than return if a character is considered as a word bound (default: spaces, new lines and tabulations)
+- `text`: the text to analyze
+- options (optional)
+- `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
+- `options.wordBound`: (optional) a function that returns a boolean value depending on if a character is considered as a word bound (default: spaces, new lines and tabulations)
 
 ## Author
 
-| [![twitter/ngryman](http://gravatar.com/avatar/2e1c2b5e153872e9fb021a6e4e376ead?size=70)](http://twitter.com/ngryman "Follow @ngryman on Twitter") |
-|---|
-| [Nicolas Gryman](http://ngryman.sh) |
+| [![twitter/ngryman](http://gravatar.com/avatar/2e1c2b5e153872e9fb021a6e4e376ead?size=70)](http://twitter.com/ngryman 'Follow @ngryman on Twitter') |
+| -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Nicolas Gryman](http://ngryman.sh)                                                                                                                |

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ npm install reading-time --production
 ### Classic
 
 ```javascript
-var readingTime = require('reading-time');
+const readingTime = require('reading-time');
 
-var stats = readingTime(text);
+const stats = readingTime(text);
 // ->
 // stats: {
 //   text: '1 min read',
@@ -40,11 +40,11 @@ var stats = readingTime(text);
 ### Stream
 
 ```javascript
-var readingTime = require('reading-time/stream');
+const readingTime = require('reading-time/stream');
 
 fs.createReadStream('foo')
   .pipe(readingTime)
-  .on('data', function(stats) {
+  .on('data', stats => {
     // ...
   });
 ```
@@ -55,8 +55,8 @@ fs.createReadStream('foo')
 
 - `text`: the text to analyze
 - options (optional)
-- `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
-- `options.wordBound`: (optional) a function that returns a boolean value depending on if a character is considered as a word bound (default: spaces, new lines and tabulations)
+  - `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
+  - `options.wordBound`: (optional) a function that returns a boolean value depending on if a character is considered as a word bound (default: spaces, new lines and tabulations)
 
 ## Author
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,18 @@
-declare module "reading-time" {
-  function readingTime(text: string): {
+declare module 'reading-time' {
+  interface IOptions {
+    wordBound?: () => boolean;
+    wordsPerMinute?: number;
+  }
+
+  interface IReadTimeResults {
     text: string;
     time: number;
     words: number;
     minutes: number;
-  };
-  
+  }
+
+  function readingTime(text: string, options?: IOptions): IReadTimeResults;
+
   namespace readingTime {}
 
   export = readingTime;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reading-time",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Medium's like reading time estimation.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Before this Pull Request, when using TypeScript an error was thrown when running the typescript compiler because the `options` were not int he typings file. I adjusted it so it could work as optional with both settings optional, too.

I also updated the readme and the version in package.json