### PR TITLE
fix typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 declare module 'reading-time' {
   interface IOptions {
-    wordBound?: () => boolean;
+    wordBound?: (char: string) => boolean;
     wordsPerMinute?: number;
   }
 


### PR DESCRIPTION
I found that wordBound function has incorrect type signature. Here is PR to fix it.