### PR TITLE
fix: Consistently return Ints for `time` to satisfy typed systems

### DIFF
--- a/lib/reading-time.js
+++ b/lib/reading-time.js
@@ -32,14 +32,16 @@ function readingTime(text, options) {
 
   // calculate the number of words
   for (i = start; i <= end;) {
-    for (; i <= end && !wordBound(text[i]); i++) ;
+    for (; i <= end && !wordBound(text[i]); i++);
     words++
-    for (; i <= end && wordBound(text[i]); i++) ;
+    for (; i <= end && wordBound(text[i]); i++);
   }
 
   // reading time stats
   var minutes = words / options.wordsPerMinute
-  var time = minutes * 60 * 1000
+  // Math.round used to resolve floating point funkyness
+  //   http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
+  var time = Math.round(minutes * 60 * 1000)
   var displayed = Math.ceil(minutes.toFixed(2))
 
   return {

--- a/test/reading-time.js
+++ b/test/reading-time.js
@@ -41,11 +41,7 @@ var test = curry(function(words, options, expect, done) {
   var res = readingTime(text, options)
   res.should.have.property('text', expect.text)
   res.should.have.property('words', words)
-  // floating point funkyness
-  //   http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
-  res.should.have.property('time').that.is.within(
-    expect.time - 0.000001, expect.time + 0.000001)
-
+  res.should.have.property('time').that.is.equal(expect.time)
   done()
 })
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -42,11 +42,7 @@ var test = curry(function(words, options, expect, done) {
   analyzer.on('data', function(res) {
     res.should.have.property('text', expect.text)
     res.should.have.property('words', words)
-    // floating point funkyness
-    //   http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
-    res.should.have.property('time').that.is.within(
-      expect.time - 0.000001, expect.time + 0.000001)
-
+    res.should.have.property('time').that.is.equal(expect.time)
     done()
   })
 


### PR DESCRIPTION
Fix the floating point issues using `Math.round` so that Ints are consistently returned for use in typed systems