### PR TITLE
feature: add preliminary support for CJK languages

### DIFF
--- a/lib/reading-time.js
+++ b/lib/reading-time.js
@@ -6,6 +6,35 @@
 
 'use strict'
 
+function checkIsCodeInRange(lowerBound, upperBound, number) {
+  return (lowerBound <= number) & (number <= upperBound)
+}
+
+function isValidCJKCharacter(c) {
+  if ('string' !== typeof c) {
+    return false
+  }
+  const charCode = c.charCodeAt(0)
+  return (
+    // Ref: https://arxiv.org/pdf/1801.07779.pdf#page=5
+    // Common CJK characters
+    checkIsCodeInRange(12352, 12543, charCode) ||
+    checkIsCodeInRange(19000, 44000, charCode)
+  )
+}
+
+function cjkWordBound(c) {
+  const charCode = c.charCodeAt(0)
+  return (
+    // CJK Symbols and Punctuation, U+3000 to U+303F
+    checkIsCodeInRange(12288, 12351, charCode) ||
+    // Full-width ASCII variants, U+FF01 to U+FF0F
+    checkIsCodeInRange(65281, 65295, charCode) ||
+    // Full-width brackets and half-width CJK punctuations, U+FF5F to U+FF64
+    checkIsCodeInRange(65375, 65380, charCode)
+  )
+}
+
 function ansiWordBound(c) {
   return (
     (' ' === c) ||
@@ -13,6 +42,14 @@ function ansiWordBound(c) {
     ('\r' === c) ||
     ('\t' === c)
   )
+}
+
+function defaultWordBound(c) {
+  // Explicit type check for black holes
+  if ('string' !== typeof c) {
+    return false
+  }
+  return ansiWordBound(c) || cjkWordBound(c)
 }
 
 function readingTime(text, options) {
@@ -24,7 +61,7 @@ function readingTime(text, options) {
   options.wordsPerMinute = options.wordsPerMinute || 200
 
   // use provided function if available
-  wordBound = options.wordBound || ansiWordBound
+  wordBound = options.wordBound || defaultWordBound
 
   // fetch bounds
   while (wordBound(text[start])) start++
@@ -32,7 +69,18 @@ function readingTime(text, options) {
 
   // calculate the number of words
   for (i = start; i <= end;) {
-    for (; i <= end && !wordBound(text[i]); i++);
+    var containsCJKWord = false
+    for (; i <= end && !wordBound(text[i]); i++) {
+      if (isValidCJKCharacter(text[i])) {
+        // avoid extra cjk character to be counted
+        if (containsCJKWord) {
+          words++
+        }
+        else {
+          containsCJKWord = true
+        }
+      }
+    }
     words++
     for (; i <= end && wordBound(text[i]); i++);
   }


### PR DESCRIPTION
This commit adds preliminary support for CJK languages.

To be specific, the original library would always output '1 minute' of reading for CJK languages. This commit fixes the issue, and more tests are on the way.