### PR TITLE
refactor: major API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ const stats = readingTime(text);
 // ->
 // stats: {
 //   minutes: 1,
-//   time: 60000
+//   time: 60000,
+//   words: 200
 // }
 console.log(`The reading time is: ${stats.minutes} min`);
 ```
@@ -52,7 +53,7 @@ fs.createReadStream('foo')
 
 ### `readingTime(text, options?)`
 
-Returns an object with `minutes` and `time` (in milliseconds).
+Returns an object with `minutes`, `time` (in milliseconds), and `words`.
 
 - `text`: the text to analyze
 - options (optional)

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ type ReadingTimeResults = {
   - `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
   - `options.wordBound`: (optional) a function that returns a boolean value depending on if a character is considered as a word bound (default: spaces, new lines and tabs)
 
-### `wordCount(text, options?)`
+### `countWords(text, options?)`
 
 Returns an object representing the word count stats:
 
@@ -90,7 +90,7 @@ Returns an object with `minutes` (rounded minute stats) and `time` (exact time i
 - options (optional)
   - `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
 
-Note that `readingTime(text, options) === readingTimeWithCount(wordCount(text, options), options)`.
+Note that `readingTime(text, options) === readingTimeWithCount(countWords(text, options), options)`.
 
 ## Help wanted!
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const stats = readingTime(text);
 // stats: {
 //   minutes: 1,
 //   time: 60000,
-//   words: 200
+//   words: {total: 200}
 // }
 console.log(`The reading time is: ${stats.minutes} min`);
 ```
@@ -55,6 +55,14 @@ fs.createReadStream('foo')
 
 Returns an object with `minutes`, `time` (in milliseconds), and `words`.
 
+```ts
+type ReadingTimeResults = {
+  minutes: number;
+  time: number;
+  words: WordCountStats;
+};
+```
+
 - `text`: the text to analyze
 - options (optional)
   - `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
@@ -62,7 +70,13 @@ Returns an object with `minutes`, `time` (in milliseconds), and `words`.
 
 ### `wordCount(text, options?)`
 
-Returns an object representing the word count stats, currently aliased to `number`.
+Returns an object representing the word count stats:
+
+```ts
+type WordCountStats = {
+  total: number;
+};
+```
 
 - `text`: the text to analyze
 - options (optional)
@@ -70,7 +84,7 @@ Returns an object representing the word count stats, currently aliased to `numbe
 
 ### `readingTimeWithCount(words, options?)`
 
-Returns an object with `minutes` and `time` (in milliseconds).
+Returns an object with `minutes` (rounded minute stats) and `time` (exact time in milliseconds).
 
 - `words`: the word count stats
 - options (optional)

--- a/README.md
+++ b/README.md
@@ -29,34 +29,53 @@ const readingTime = require('reading-time');
 const stats = readingTime(text);
 // ->
 // stats: {
-//   text: '1 min read',
 //   minutes: 1,
-//   time: 60000,
-//   words: 200
+//   time: 60000
 // }
+console.log(`The reading time is: ${stats.minutes} min`);
 ```
 
 ### Stream
 
 ```javascript
-const {ReadingTimeStream} = require('reading-time');
+const {ReadingTimeStream, readingTimeWithCount} = require('reading-time');
 
 const analyzer = new ReadingTimeStream();
 fs.createReadStream('foo')
   .pipe(analyzer)
-  .on('data', stats => {
-    // ...
+  .on('data', (count) => {
+    console.log(`The reading time is: ${readingTimeWithCount(count).minutes} min`);
   });
 ```
 
 ## API
 
-`readingTime(text, options?)`
+### `readingTime(text, options?)`
+
+Returns an object with `minutes` and `time` (in milliseconds).
 
 - `text`: the text to analyze
 - options (optional)
   - `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
-  - `options.wordBound`: (optional) a function that returns a boolean value depending on if a character is considered as a word bound (default: spaces, new lines and tabulations)
+  - `options.wordBound`: (optional) a function that returns a boolean value depending on if a character is considered as a word bound (default: spaces, new lines and tabs)
+
+### `wordCount(text, options?)`
+
+Returns an object representing the word count stats, currently aliased to `number`.
+
+- `text`: the text to analyze
+- options (optional)
+  - `options.wordBound`: (optional) a function that returns a boolean value depending on if a character is considered as a word bound (default: spaces, new lines and tabs)
+
+### `readingTimeWithCount(words, options?)`
+
+Returns an object with `minutes` and `time` (in milliseconds).
+
+- `words`: the word count stats
+- options (optional)
+  - `options.wordsPerMinute`: (optional) the words per minute an average reader can read (default: 200)
+
+Note that `readingTime(text, options) === readingTimeWithCount(wordCount(text, options), options)`.
 
 ## Help wanted!
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "words per minute"
   ],
   "author": "Nicolas Gryman <ngryman@gmail.com> (http://ngryman.sh)",
+  "contributors": ["Joshua Chen <sidachen2003@gmail.com> (https://joshcena.com)"],
   "license": "MIT",
   "devDependencies": {
     "@types/chai": "^4.2.21",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import readingTime from './reading-time'
+import readingTime, { wordCount, readingTimeWithCount } from './reading-time'
 import ReadingTimeStream from './stream'
 
 // This part is to make TS happy
@@ -10,5 +10,7 @@ export default readingTime
 // decouples it from the exports object, which TS export compiles to
 module.exports = readingTime
 module.exports.default = readingTime
+module.exports.wordCount = wordCount
+module.exports.readingTimeWithCount = readingTimeWithCount
 module.exports.ReadingTimeStream = ReadingTimeStream
 module.exports.__esModule = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import readingTime, { wordCount, readingTimeWithCount } from './reading-time'
+import readingTime, { countWords, readingTimeWithCount } from './reading-time'
 import ReadingTimeStream from './stream'
 
 // This part is to make TS happy
-export { ReadingTimeStream, wordCount, readingTimeWithCount }
+export { ReadingTimeStream, countWords, readingTimeWithCount }
 export default readingTime
 
 // Wacky way to support const readingTime = require('reading-time') :(
@@ -10,7 +10,7 @@ export default readingTime
 // decouples it from the exports object, which TS export compiles to
 module.exports = readingTime
 module.exports.default = readingTime
-module.exports.wordCount = wordCount
+module.exports.countWords = countWords
 module.exports.readingTimeWithCount = readingTimeWithCount
 module.exports.ReadingTimeStream = ReadingTimeStream
 module.exports.__esModule = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import readingTime, { wordCount, readingTimeWithCount } from './reading-time'
 import ReadingTimeStream from './stream'
 
 // This part is to make TS happy
-export { ReadingTimeStream }
+export { ReadingTimeStream, wordCount, readingTimeWithCount }
 export default readingTime
 
 // Wacky way to support const readingTime = require('reading-time') :(

--- a/src/reading-time.ts
+++ b/src/reading-time.ts
@@ -4,7 +4,7 @@
  * MIT Licensed
  */
 
-import type { Options, ReadingTimeStats, WordCountStats, ReadingTimeResults } from 'reading-time'
+import type { Options, ReadingTimeStats, WordCountStats, ReadingTimeResult } from 'reading-time'
 
 type WordBoundFunction = Options['wordBound']
 
@@ -58,7 +58,7 @@ const isPunctuation: WordBoundFunction = (c) => {
   )
 }
 
-export function wordCount(text: string, options: Options = {}): WordCountStats {
+export function countWords(text: string, options: Options = {}): WordCountStats {
   let words = 0, start = 0, end = text.length - 1
   const { wordBound: isWordBound = isAnsiWordBound } = options
 
@@ -112,8 +112,8 @@ export function readingTimeWithCount(
   }
 }
 
-export default function readingTime(text: string, options: Options = {}): ReadingTimeResults {
-  const words = wordCount(text, options)
+export default function readingTime(text: string, options: Options = {}): ReadingTimeResult {
+  const words = countWords(text, options)
   return {
     ...readingTimeWithCount(words, options),
     words

--- a/src/reading-time.ts
+++ b/src/reading-time.ts
@@ -60,9 +60,7 @@ const isPunctuation: WordBoundFunction = (c) => {
 
 export function wordCount(text: string, options: Options = {}): WordCountStats {
   let words = 0, start = 0, end = text.length - 1
-  const {
-    wordBound: isWordBound = isAnsiWordBound
-  } = options
+  const { wordBound: isWordBound = isAnsiWordBound } = options
 
   // fetch bounds
   while (isWordBound(text[start])) start++
@@ -93,19 +91,17 @@ export function wordCount(text: string, options: Options = {}): WordCountStats {
       }
     }
   }
-  return words
+  return { total: words }
 }
 
 export function readingTimeWithCount(
   words: WordCountStats,
   options: Options = {}
 ): ReadingTimeStats {
-  const {
-    wordsPerMinute = 200
-  } = options
+  const { wordsPerMinute = 200 } = options
   // reading time stats
-  const minutes = words / wordsPerMinute
-  // Math.round used to resolve floating point funkyness
+  const minutes = words.total / wordsPerMinute
+  // Math.round used to resolve floating point funkiness
   //   http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
   const time = Math.round(minutes * 60 * 1000)
   const displayed = Math.ceil(parseFloat(minutes.toFixed(2)))

--- a/src/reading-time.ts
+++ b/src/reading-time.ts
@@ -4,7 +4,7 @@
  * MIT Licensed
  */
 
-import type { Options, ReadTimeResults } from 'reading-time'
+import type { Options, ReadTimeResults, WordCountResults } from 'reading-time'
 
 type WordBoundFunction = Options['wordBound']
 
@@ -58,10 +58,9 @@ const isPunctuation: WordBoundFunction = (c) => {
   )
 }
 
-function readingTime(text: string, options: Options = {}): ReadTimeResults {
+export function wordCount(text: string, options: Options = {}): WordCountResults {
   let words = 0, start = 0, end = text.length - 1
   const {
-    wordsPerMinute = 200,
     wordBound: isWordBound = isAnsiWordBound
   } = options
 
@@ -94,7 +93,16 @@ function readingTime(text: string, options: Options = {}): ReadTimeResults {
       }
     }
   }
+  return words
+}
 
+export function readingTimeWithCount(
+  words: WordCountResults,
+  options: Options = {}
+): ReadTimeResults {
+  const {
+    wordsPerMinute = 200
+  } = options
   // reading time stats
   const minutes = words / wordsPerMinute
   // Math.round used to resolve floating point funkyness
@@ -103,11 +111,11 @@ function readingTime(text: string, options: Options = {}): ReadTimeResults {
   const displayed = Math.ceil(parseFloat(minutes.toFixed(2)))
 
   return {
-    text: displayed + ' min read',
-    minutes,
-    time,
-    words
+    minutes: displayed,
+    time
   }
 }
 
-export default readingTime
+export default function readingTime(text: string, options: Options = {}): ReadTimeResults {
+  return readingTimeWithCount(wordCount(text, options), options)
+}

--- a/src/reading-time.ts
+++ b/src/reading-time.ts
@@ -4,7 +4,7 @@
  * MIT Licensed
  */
 
-import type { Options, ReadTimeResults, WordCountResults } from 'reading-time'
+import type { Options, ReadingTimeStats, WordCountStats, ReadingTimeResults } from 'reading-time'
 
 type WordBoundFunction = Options['wordBound']
 
@@ -58,7 +58,7 @@ const isPunctuation: WordBoundFunction = (c) => {
   )
 }
 
-export function wordCount(text: string, options: Options = {}): WordCountResults {
+export function wordCount(text: string, options: Options = {}): WordCountStats {
   let words = 0, start = 0, end = text.length - 1
   const {
     wordBound: isWordBound = isAnsiWordBound
@@ -97,9 +97,9 @@ export function wordCount(text: string, options: Options = {}): WordCountResults
 }
 
 export function readingTimeWithCount(
-  words: WordCountResults,
+  words: WordCountStats,
   options: Options = {}
-): ReadTimeResults {
+): ReadingTimeStats {
   const {
     wordsPerMinute = 200
   } = options
@@ -116,6 +116,10 @@ export function readingTimeWithCount(
   }
 }
 
-export default function readingTime(text: string, options: Options = {}): ReadTimeResults {
-  return readingTimeWithCount(wordCount(text, options), options)
+export default function readingTime(text: string, options: Options = {}): ReadingTimeResults {
+  const words = wordCount(text, options)
+  return {
+    ...readingTimeWithCount(words, options),
+    words
+  }
 }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -4,7 +4,7 @@
  * MIT Licensed
  */
 
-import { wordCount } from './reading-time'
+import { countWords } from './reading-time'
 import { Transform, TransformCallback } from 'stream'
 import type { Options, WordCountStats } from 'reading-time'
 
@@ -20,7 +20,7 @@ class ReadingTimeStream extends Transform {
   }
 
   _transform(chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback): void {
-    const stats = wordCount(chunk.toString(encoding), this.options)
+    const stats = countWords(chunk.toString(encoding), this.options)
     this.stats.total += stats.total
     callback()
   }

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -6,11 +6,11 @@
 
 import { wordCount } from './reading-time'
 import { Transform, TransformCallback } from 'stream'
-import type { Options, WordCountResults } from 'reading-time'
+import type { Options, WordCountStats } from 'reading-time'
 
 class ReadingTimeStream extends Transform {
   options: Options;
-  stats: WordCountResults;
+  stats: WordCountStats;
 
   constructor(options: Options = {}) {
     super({ objectMode: true })

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -16,12 +16,12 @@ class ReadingTimeStream extends Transform {
     super({ objectMode: true })
 
     this.options = options
-    this.stats = 0
+    this.stats = { total: 0 }
   }
 
   _transform(chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback): void {
     const stats = wordCount(chunk.toString(encoding), this.options)
-    this.stats += stats
+    this.stats.total += stats.total
     callback()
   }
 

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -4,39 +4,28 @@
  * MIT Licensed
  */
 
-import readingTime from './reading-time'
+import { wordCount } from './reading-time'
 import { Transform, TransformCallback } from 'stream'
-import type { Options, ReadTimeResults } from 'reading-time'
+import type { Options, WordCountResults } from 'reading-time'
 
 class ReadingTimeStream extends Transform {
   options: Options;
-  stats: ReadTimeResults;
+  stats: WordCountResults;
 
   constructor(options: Options = {}) {
     super({ objectMode: true })
 
     this.options = options
-    this.stats = {
-      text: '',
-      minutes: 0,
-      time: 0,
-      words: 0
-    }
+    this.stats = 0
   }
 
   _transform(chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback): void {
-    const stats = readingTime(chunk.toString(encoding), this.options)
-
-    this.stats.minutes += stats.minutes
-    this.stats.time += stats.time
-    this.stats.words += stats.words
-
+    const stats = wordCount(chunk.toString(encoding), this.options)
+    this.stats += stats
     callback()
   }
 
   _flush(callback: TransformCallback): void {
-    this.stats.text = Math.ceil(parseFloat(this.stats.minutes.toFixed(2))) + ' min read'
-
     this.push(this.stats)
     callback()
   }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,17 +1,17 @@
 declare module 'reading-time' {
   import { Transform, TransformCallback } from 'stream'
 
-  export interface Options {
+  export type Options = {
     wordBound?: (char: string) => boolean;
     wordsPerMinute?: number;
   }
 
-  export interface ReadingTimeStats {
+  export type ReadingTimeStats = {
     time: number;
     minutes: number;
   }
 
-  export interface WordCountStats {
+  export type WordCountStats = {
     total: number;
   }
 
@@ -23,11 +23,11 @@ declare module 'reading-time' {
     _flush: (callback: TransformCallback) => void;
   }
 
-  export interface ReadingTimeResults extends ReadingTimeStats {
+  export type ReadingTimeResult = ReadingTimeStats & {
     words: WordCountStats;
   }
 
-  export function wordCount(text: string, options?: Options): WordCountStats
+  export function countWords(text: string, options?: Options): WordCountStats
   export function readingTimeWithCount(words: WordCountStats, options?: Options): ReadingTimeStats
-  export default function readingTime(text: string, options?: Options): ReadingTimeResults
+  export default function readingTime(text: string, options?: Options): ReadingTimeResult
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,22 +6,26 @@ declare module 'reading-time' {
     wordsPerMinute?: number;
   }
 
-  export interface ReadTimeResults {
+  export interface ReadingTimeStats {
     time: number;
     minutes: number;
   }
 
-  export type WordCountResults = number;
+  export type WordCountStats = number;
 
   export class ReadingTimeStream extends Transform {
-    stats: WordCountResults;
+    stats: WordCountStats;
     options: Options;
     constructor(options?: Options);
     _transform: (chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback) => void;
     _flush: (callback: TransformCallback) => void;
   }
 
-  export function wordCount(text: string, options?: Options): WordCountResults
-  export function readingTimeWithCount(words: WordCountResults, options?: Options): ReadTimeResults
-  export default function readingTime(text: string, options?: Options): ReadTimeResults
+  export interface ReadingTimeResults extends ReadingTimeStats {
+    words: WordCountStats;
+  }
+
+  export function wordCount(text: string, options?: Options): WordCountStats
+  export function readingTimeWithCount(words: WordCountStats, options?: Options): ReadingTimeStats
+  export default function readingTime(text: string, options?: Options): ReadingTimeResults
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -7,19 +7,21 @@ declare module 'reading-time' {
   }
 
   export interface ReadTimeResults {
-    text: string;
     time: number;
-    words: number;
     minutes: number;
   }
 
+  export type WordCountResults = number;
+
   export class ReadingTimeStream extends Transform {
-    stats: ReadTimeResults;
+    stats: WordCountResults;
     options: Options;
     constructor(options?: Options);
     _transform: (chunk: Buffer, encoding: BufferEncoding, callback: TransformCallback) => void;
     _flush: (callback: TransformCallback) => void;
   }
 
+  export function wordCount(text: string, options?: Options): WordCountResults
+  export function readingTimeWithCount(words: WordCountResults, options?: Options): ReadTimeResults
   export default function readingTime(text: string, options?: Options): ReadTimeResults
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -11,7 +11,9 @@ declare module 'reading-time' {
     minutes: number;
   }
 
-  export type WordCountStats = number;
+  export interface WordCountStats {
+    total: number;
+  }
 
   export class ReadingTimeStream extends Transform {
     stats: WordCountStats;

--- a/test/reading-time.spec.ts
+++ b/test/reading-time.spec.ts
@@ -34,7 +34,7 @@ const test = (words: number | string, expect: Partial<ReadingTimeResults>, optio
       res.should.have.property('time', expect.time)
     }
     if (expect.words) {
-      res.should.have.property('words', expect.words)
+      res.should.have.property('words').to.deep.equal(expect.words)
     }
     done()
   }
@@ -138,36 +138,36 @@ describe('readingTime()', () => {
 describe('readingTime CJK', () => {
   it('should handle a CJK paragraph',
     test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', {
-      words: 22
+      words: { total: 22 }
     }))
 
   it('should handle a CJK paragraph with Latin words',
     test('你会说English吗？', {
-      words: 5
+      words: { total: 5 }
     }))
 
   it('should handle a CJK paragraph with Latin punctuation',
     test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', {
-      words: 22
+      words: { total: 22 }
     }))
 
   it('should handle a CJK paragraph starting and terminating in Latin words',
     test('JoshCena喜欢GitHub', {
-      words: 4
+      words: { total: 4 }
     }))
 
   it('should handle a typical Korean paragraph',
     test('이것은 한국어 단락입니다', {
-      words: 11
+      words: { total: 11 }
     }))
 
   it('should handle a typical Japanese paragraph',
     test('天気がいいから、散歩しましょう', {
-      words: 14
+      words: { total: 14 }
     }))
 
   it('should treat Katakana as one word',
     test('メガナイトありませんか？', {
-      words: 7
+      words: { total: 7 }
     }))
 })

--- a/test/reading-time.spec.ts
+++ b/test/reading-time.spec.ts
@@ -6,11 +6,11 @@
 
 import readingTime from '../src'
 import chai from 'chai'
-import { Options, ReadTimeResults } from 'reading-time'
+import { Options, ReadingTimeResults } from 'reading-time'
 
 chai.should()
 
-const test = (words: number | string, expect: Partial<ReadTimeResults>, options?: Options) =>
+const test = (words: number | string, expect: Partial<ReadingTimeResults>, options?: Options) =>
   (done: () => void) => {
     const text = 'number' === typeof words ? generateText(words) : words
 
@@ -32,6 +32,9 @@ const test = (words: number | string, expect: Partial<ReadTimeResults>, options?
     }
     if (expect.time) {
       res.should.have.property('time', expect.time)
+    }
+    if (expect.words) {
+      res.should.have.property('words', expect.words)
     }
     done()
   }
@@ -135,36 +138,36 @@ describe('readingTime()', () => {
 describe('readingTime CJK', () => {
   it('should handle a CJK paragraph',
     test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', {
-      time: 6600
+      words: 22
     }))
 
   it('should handle a CJK paragraph with Latin words',
     test('你会说English吗？', {
-      time: 1500
+      words: 5
     }))
 
   it('should handle a CJK paragraph with Latin punctuation',
     test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', {
-      time: 6600
+      words: 22
     }))
 
   it('should handle a CJK paragraph starting and terminating in Latin words',
     test('JoshCena喜欢GitHub', {
-      time: 1200
+      words: 4
     }))
 
   it('should handle a typical Korean paragraph',
     test('이것은 한국어 단락입니다', {
-      time: 3300
+      words: 11
     }))
 
   it('should handle a typical Japanese paragraph',
     test('天気がいいから、散歩しましょう', {
-      time: 4200
+      words: 14
     }))
 
   it('should treat Katakana as one word',
     test('メガナイトありませんか？', {
-      time: 2100
+      words: 7
     }))
 })

--- a/test/reading-time.spec.ts
+++ b/test/reading-time.spec.ts
@@ -27,10 +27,9 @@ const test = (words: number | string, expect: Partial<ReadTimeResults>, options?
     }
 
     const res = readingTime(text, options)
-    if (expect.text) {
-      res.should.have.property('text', expect.text)
+    if (expect.minutes) {
+      res.should.have.property('minutes', expect.minutes)
     }
-    res.should.have.property('words', expect.words ?? words)
     if (expect.time) {
       res.should.have.property('time', expect.time)
     }
@@ -56,79 +55,79 @@ function generateText(words: number) {
 describe('readingTime()', () => {
   it('should handle less than 1 minute text',
     test(2, {
-      text: '1 min read',
+      minutes: 1,
       time: 600
     }))
 
   it('should handle less than 1 minute text',
     test(50, {
-      text: '1 min read',
+      minutes: 1,
       time: 15000
     }))
 
   it('should handle 1 minute text',
     test(100, {
-      text: '1 min read',
+      minutes: 1,
       time: 30000
     }))
 
   it('should handle 2 minutes text',
     test(300, {
-      text: '2 min read',
+      minutes: 2,
       time: 90000
     }))
 
   it('should handle a very long text',
     test(500, {
-      text: '3 min read',
+      minutes: 3,
       time: 150000
     }))
 
   it('should handle text containing multiple successive whitespaces',
     test('word  word    word', {
-      text: '1 min read',
+      minutes: 1,
       time: 900
     }))
 
   it('should handle text starting with whitespaces',
     test('   word word word', {
-      text: '1 min read',
+      minutes: 1,
       time: 900
     }))
 
   it('should handle text ending with whitespaces',
     test('word word word   ', {
-      text: '1 min read',
+      minutes: 1,
       time: 900
     }))
 
   it('should handle text containing links',
     test('word http://ngryman.sh word', {
-      text: '1 min read',
+      minutes: 1,
       time: 900
     }))
 
   it('should handle text containing markdown links',
     test('word [blog](http://ngryman.sh) word', {
-      text: '1 min read',
+      minutes: 1,
       time: 900
     }))
 
   it('should handle text containing one word correctly',
     test('0', {
-      text: '1 min read',
+      minutes: 1,
       time: 300
     }))
 
   it('should handle text containing a black hole',
     test('', {
-      text: '0 min read',
+      minutes: 0,
       time: 0
     }))
 
   it('should accept a custom word per minutes value',
     test(200, {
-      text: '2 min read',
+      minutes: 2,
       time: 120000
     }, { wordsPerMinute: 100 }))
 })
@@ -136,36 +135,36 @@ describe('readingTime()', () => {
 describe('readingTime CJK', () => {
   it('should handle a CJK paragraph',
     test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', {
-      words: 22
+      time: 6600
     }))
 
   it('should handle a CJK paragraph with Latin words',
     test('你会说English吗？', {
-      words: 5
+      time: 1500
     }))
 
   it('should handle a CJK paragraph with Latin punctuation',
     test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', {
-      words: 22
+      time: 6600
     }))
 
   it('should handle a CJK paragraph starting and terminating in Latin words',
     test('JoshCena喜欢GitHub', {
-      words: 4
+      time: 1200
     }))
 
   it('should handle a typical Korean paragraph',
     test('이것은 한국어 단락입니다', {
-      words: 11
+      time: 3300
     }))
 
   it('should handle a typical Japanese paragraph',
     test('天気がいいから、散歩しましょう', {
-      words: 14
+      time: 4200
     }))
 
   it('should treat Katakana as one word',
     test('メガナイトありませんか？', {
-      words: 7
+      time: 2100
     }))
 })

--- a/test/reading-time.spec.ts
+++ b/test/reading-time.spec.ts
@@ -6,11 +6,11 @@
 
 import readingTime from '../src'
 import chai from 'chai'
-import { Options, ReadingTimeResults } from 'reading-time'
+import { Options, ReadingTimeResult } from 'reading-time'
 
 chai.should()
 
-const test = (words: number | string, expect: Partial<ReadingTimeResults>, options?: Options) =>
+const test = (words: number | string, expect: Partial<ReadingTimeResult>, options?: Options) =>
   (done: () => void) => {
     const text = 'number' === typeof words ? generateText(words) : words
 

--- a/test/stream.spec.ts
+++ b/test/stream.spec.ts
@@ -6,11 +6,11 @@
 
 import { ReadingTimeStream } from '../src'
 import chai from 'chai'
-import { Options, ReadTimeResults } from 'reading-time'
+import { Options, WordCountResults } from 'reading-time'
 
 chai.should()
 
-const test = (words: number | string, expect: Partial<ReadTimeResults>, options?: Options) =>
+const test = (words: number | string, expect: WordCountResults, options?: Options) =>
   (done: () => void) => {
     const chunks = 'number' === typeof words ? generateChunks(words) : [Buffer.from(words)]
 
@@ -28,13 +28,7 @@ const test = (words: number | string, expect: Partial<ReadTimeResults>, options?
 
     const analyzer = new ReadingTimeStream(options)
     analyzer.on('data', (res) => {
-      if (expect.text) {
-        res.should.have.property('text', expect.text)
-      }
-      res.should.have.property('words', expect.words ?? words)
-      if (expect.time) {
-        res.should.have.property('time', expect.time)
-      }
+      res.should.equal(expect)
       done()
     })
 
@@ -67,117 +61,64 @@ function generateChunks(words: number) {
 
 describe('readingTime stream', () => {
   it('should handle less than 1 minute text',
-    test(2, {
-      text: '1 min read',
-      time: 600
-    }))
+    test(2, 2))
 
   it('should handle less than 1 minute text',
-    test(50, {
-      text: '1 min read',
-      time: 15000
-    }))
+    test(50, 50))
 
   it('should handle 1 minute text',
-    test(100, {
-      text: '1 min read',
-      time: 30000
-    }))
+    test(100, 100))
 
   it('should handle 2 minutes text',
-    test(300, {
-      text: '2 min read',
-      time: 90000
-    }))
+    test(300, 300))
 
   it('should handle a very long text',
-    test(500, {
-      text: '3 min read',
-      time: 150000
-    }))
+    test(500, 500))
 
   it('should handle text containing multiple successive whitespaces',
-    test('word  word    word', {
-      text: '1 min read',
-      time: 900
-    }))
+    test('word  word    word', 3))
 
   it('should handle text starting with whitespaces',
-    test('   word word word', {
-      text: '1 min read',
-      time: 900
-    }))
+    test('   word word word', 3))
 
   it('should handle text ending with whitespaces',
-    test('word word word   ', {
-      text: '1 min read',
-      time: 900
-    }))
+    test('word word word   ', 3))
 
   it('should handle text containing links',
-    test('word http://ngryman.sh word', {
-      text: '1 min read',
-      time: 900
-    }))
+    test('word http://ngryman.sh word', 3))
 
   it('should handle text containing markdown links',
-    test('word [blog](http://ngryman.sh) word', {
-      text: '1 min read',
-      time: 900
-    }))
+    test('word [blog](http://ngryman.sh) word', 3))
 
   it('should handle text containing one word correctly',
-    test('0', {
-      text: '1 min read',
-      time: 300
-    }))
+    test('0', 1))
 
   it('should handle text containing a black hole',
-    test('', {
-      text: '0 min read',
-      time: 0
-    }))
+    test('', 0))
 
   it('should accept a custom word per minutes value',
-    test(200, {
-      text: '2 min read',
-      time: 120000
-    }, { wordsPerMinute: 100 }))
+    test(200, 200, { wordsPerMinute: 100 }))
 })
 
 describe('readingTime stream CJK', () => {
   it('should handle a CJK paragraph',
-    test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', {
-      words: 22
-    }))
+    test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', 22))
 
   it('should handle a CJK paragraph with Latin words',
-    test('你会说English吗？', {
-      words: 5
-    }))
+    test('你会说English吗？', 5))
 
   it('should handle a CJK paragraph with Latin punctuation',
-    test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', {
-      words: 22
-    }))
+    test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', 22))
 
   it('should handle a CJK paragraph starting and terminating in Latin words',
-    test('JoshCena喜欢GitHub', {
-      words: 4
-    }))
+    test('JoshCena喜欢GitHub', 4))
 
   it('should handle a typical Korean paragraph',
-    test('이것은 한국어 단락입니다', {
-      words: 11
-    }))
+    test('이것은 한국어 단락입니다', 11))
 
   it('should handle a typical Japanese paragraph',
-    test('天気がいいから、散歩しましょう', {
-      words: 14
-    }))
+    test('天気がいいから、散歩しましょう', 14))
 
   it('should treat Katakana as one word',
-    test('メガナイトありませんか？', {
-      words: 7
-    }))
+    test('メガナイトありませんか？', 7))
 })

--- a/test/stream.spec.ts
+++ b/test/stream.spec.ts
@@ -6,11 +6,11 @@
 
 import { ReadingTimeStream } from '../src'
 import chai from 'chai'
-import { Options, WordCountResults } from 'reading-time'
+import { Options, WordCountStats } from 'reading-time'
 
 chai.should()
 
-const test = (words: number | string, expect: WordCountResults, options?: Options) =>
+const test = (words: number | string, expect: WordCountStats, options?: Options) =>
   (done: () => void) => {
     const chunks = 'number' === typeof words ? generateChunks(words) : [Buffer.from(words)]
 
@@ -60,65 +60,29 @@ function generateChunks(words: number) {
 }
 
 describe('readingTime stream', () => {
-  it('should handle less than 1 minute text',
-    test(2, 2))
-
-  it('should handle less than 1 minute text',
-    test(50, 50))
-
-  it('should handle 1 minute text',
-    test(100, 100))
-
-  it('should handle 2 minutes text',
-    test(300, 300))
-
-  it('should handle a very long text',
-    test(500, 500))
-
-  it('should handle text containing multiple successive whitespaces',
-    test('word  word    word', 3))
-
-  it('should handle text starting with whitespaces',
-    test('   word word word', 3))
-
-  it('should handle text ending with whitespaces',
-    test('word word word   ', 3))
-
-  it('should handle text containing links',
-    test('word http://ngryman.sh word', 3))
-
-  it('should handle text containing markdown links',
-    test('word [blog](http://ngryman.sh) word', 3))
-
-  it('should handle text containing one word correctly',
-    test('0', 1))
-
-  it('should handle text containing a black hole',
-    test('', 0))
-
-  it('should accept a custom word per minutes value',
-    test(200, 200, { wordsPerMinute: 100 }))
+  it('should handle less than 1 minute text', test(2, 2))
+  it('should handle less than 1 minute text', test(50, 50))
+  it('should handle 1 minute text', test(100, 100))
+  it('should handle 2 minutes text', test(300, 300))
+  it('should handle a very long text', test(500, 500))
+  it('should handle text containing multiple successive whitespaces', test('word  word    word', 3))
+  it('should handle text starting with whitespaces', test('   word word word', 3))
+  it('should handle text ending with whitespaces', test('word word word   ', 3))
+  it('should handle text containing links', test('word http://ngryman.sh word', 3))
+  it('should handle text containing markdown links', test('word [blog](http://ngryman.sh) word', 3))
+  it('should handle text containing one word correctly', test('0', 1))
+  it('should handle text containing a black hole', test('', 0))
+  it('should accept a custom word per minutes value', test(200, 200, { wordsPerMinute: 100 }))
 })
 
 describe('readingTime stream CJK', () => {
-  it('should handle a CJK paragraph',
-    test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', 22))
-
-  it('should handle a CJK paragraph with Latin words',
-    test('你会说English吗？', 5))
-
+  it('should handle a CJK paragraph', test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', 22))
+  it('should handle a CJK paragraph with Latin words', test('你会说English吗？', 5))
   it('should handle a CJK paragraph with Latin punctuation',
     test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', 22))
-
   it('should handle a CJK paragraph starting and terminating in Latin words',
     test('JoshCena喜欢GitHub', 4))
-
-  it('should handle a typical Korean paragraph',
-    test('이것은 한국어 단락입니다', 11))
-
-  it('should handle a typical Japanese paragraph',
-    test('天気がいいから、散歩しましょう', 14))
-
-  it('should treat Katakana as one word',
-    test('メガナイトありませんか？', 7))
+  it('should handle a typical Korean paragraph', test('이것은 한국어 단락입니다', 11))
+  it('should handle a typical Japanese paragraph', test('天気がいいから、散歩しましょう', 14))
+  it('should treat Katakana as one word', test('メガナイトありませんか？', 7))
 })

--- a/test/stream.spec.ts
+++ b/test/stream.spec.ts
@@ -28,7 +28,7 @@ const test = (words: number | string, expect: WordCountStats, options?: Options)
 
     const analyzer = new ReadingTimeStream(options)
     analyzer.on('data', (res) => {
-      res.should.equal(expect)
+      res.should.deep.equal(expect)
       done()
     })
 
@@ -60,29 +60,32 @@ function generateChunks(words: number) {
 }
 
 describe('readingTime stream', () => {
-  it('should handle less than 1 minute text', test(2, 2))
-  it('should handle less than 1 minute text', test(50, 50))
-  it('should handle 1 minute text', test(100, 100))
-  it('should handle 2 minutes text', test(300, 300))
-  it('should handle a very long text', test(500, 500))
-  it('should handle text containing multiple successive whitespaces', test('word  word    word', 3))
-  it('should handle text starting with whitespaces', test('   word word word', 3))
-  it('should handle text ending with whitespaces', test('word word word   ', 3))
-  it('should handle text containing links', test('word http://ngryman.sh word', 3))
-  it('should handle text containing markdown links', test('word [blog](http://ngryman.sh) word', 3))
-  it('should handle text containing one word correctly', test('0', 1))
-  it('should handle text containing a black hole', test('', 0))
-  it('should accept a custom word per minutes value', test(200, 200, { wordsPerMinute: 100 }))
+  it('should handle less than 1 minute text', test(2, { total: 2 }))
+  it('should handle less than 1 minute text', test(50, { total: 50 }))
+  it('should handle 1 minute text', test(100, { total: 100 }))
+  it('should handle 2 minutes text', test(300, { total: 300 }))
+  it('should handle a very long text', test(500, { total: 500 }))
+  it('should handle text containing multiple successive whitespaces',
+    test('word  word    word', { total: 3 }))
+  it('should handle text starting with whitespaces', test('   word word word', { total: 3 }))
+  it('should handle text ending with whitespaces', test('word word word   ', { total: 3 }))
+  it('should handle text containing links', test('word http://ngryman.sh word', { total: 3 }))
+  it('should handle text containing markdown links',
+    test('word [blog](http://ngryman.sh) word', { total: 3 }))
+  it('should handle text containing one word correctly', test('0', { total: 1 }))
+  it('should handle text containing a black hole', test('', { total: 0 }))
+  it('should accept a custom word per minutes value',
+    test(200, { total: 200 }, { wordsPerMinute: 100 }))
 })
 
 describe('readingTime stream CJK', () => {
-  it('should handle a CJK paragraph', test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', 22))
-  it('should handle a CJK paragraph with Latin words', test('你会说English吗？', 5))
+  it('should handle a CJK paragraph', test('今天，我要说中文！（没错，现在这个库也完全支持中文了）', { total: 22 }))
+  it('should handle a CJK paragraph with Latin words', test('你会说English吗？', { total: 5 }))
   it('should handle a CJK paragraph with Latin punctuation',
-    test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', 22))
+    test('科学文章中, 经常使用英语标点... (虽然这段话并不科学)', { total: 22 }))
   it('should handle a CJK paragraph starting and terminating in Latin words',
-    test('JoshCena喜欢GitHub', 4))
-  it('should handle a typical Korean paragraph', test('이것은 한국어 단락입니다', 11))
-  it('should handle a typical Japanese paragraph', test('天気がいいから、散歩しましょう', 14))
-  it('should treat Katakana as one word', test('メガナイトありませんか？', 7))
+    test('JoshCena喜欢GitHub', { total: 4 }))
+  it('should handle a typical Korean paragraph', test('이것은 한국어 단락입니다', { total: 11 }))
+  it('should handle a typical Japanese paragraph', test('天気がいいから、散歩しましょう', { total: 14 }))
+  it('should treat Katakana as one word', test('メガナイトありませんか？', { total: 7 }))
 })


### PR DESCRIPTION
Resolve #18.

## Breaking changes

- The `readingTime` now only returns `time` (milliseconds) and `minutes`—both are integers. No strings or decimals are returned. You can always convert them to representations you need.
  - **Why?** Removal of `text` improves ease of i18n as we are no longer biased towards English. `minutes` used to return a decimal which is trivially `time / 60000` but with a lot of floating point funkiness.
- The `ReadingTimeStream` now only stores word count as its state—it is the equivalent of `countWords()`, not the bulk of `readingTime()`. Users still need to run `readingTimeWithCount()` to get the result.
  - **Why?** To improve composability, because a lot of the implementation details that go on under the hood are not controllable to the user, so a granular API is more desirable.

I may be cutting too many features here. Open to discussion.

## Features

New functions `countWords` and `readingTimeWithCount`. Right now `WordCountResults = { total: number }`, but in the future we can have `whitespace`, `punctuation`, `CJK`, `words`, etc., each with its own `wordPerMinute` setting when passed to `readingTimeWithCount`!
