### PR TITLE
add additional Math.ceil() for displayed time

### DIFF
--- a/src/reading-time.ts
+++ b/src/reading-time.ts
@@ -107,7 +107,7 @@ export function readingTimeWithCount(
   const displayed = Math.ceil(parseFloat(minutes.toFixed(2)))
 
   return {
-    minutes: displayed,
+    minutes: Math.ceil(displayed),
     time
   }
 }


### PR DESCRIPTION
hey everyone!

This PR should fix the issue of not displaying a nice round number (closes #55)
I added another `Math.ceil()` as a quick workaround