### PR TITLE
docs: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ const readingTime = require('reading-time/lib/reading-time');
 const stats = readingTime(text);
 // ->
 // stats: {
+//   text: "1 min read",
 //   minutes: 1,
 //   time: 60000,
 //   words: {total: 200}
@@ -72,10 +73,11 @@ Yes. You need to provide the appropriate polyfills. Please refer to your bundler
 
 ### `readingTime(text, options?)`
 
-Returns an object with `minutes`, `time` (in milliseconds), and `words`.
+Returns an object with `text`, `minutes`, `time` (in milliseconds), and `words`.
 
 ```ts
 type ReadingTimeResults = {
+  text: string;
   minutes: number;
   time: number;
   words: WordCountStats;


### PR DESCRIPTION
The return value I got when using the `readingTime` API is as shown in the figure:
![image](https://github.com/user-attachments/assets/3145a254-ea91-4094-835b-e20d4d118a00)

The part of the code that returns the value of the `readingTime` function in readingTime.js is as follows:
```js
  return {
    text: displayed + ' min read',
    minutes: minutes,
    time: time,
    words: words
  }
```
There was an omission in the README.md, so I updated the README.md.
