### PR TITLE
refactor: use node: for built-in modules

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -5,7 +5,7 @@
  */
 
 import { countWords } from './reading-time'
-import { Transform, TransformCallback } from 'stream'
+import { Transform, TransformCallback } from 'node:stream'
 import type { Options, WordCountStats } from './types'
 
 class ReadingTimeStream extends Transform {


### PR DESCRIPTION
new node standard use node:* format to import nodes runtime packages